### PR TITLE
Fix sha256 for windows binary

### DIFF
--- a/plugins/CastleRocktronics.json
+++ b/plugins/CastleRocktronics.json
@@ -10,7 +10,7 @@
   "downloads": {
     "win": {
       "download": "https://github.com/KieranPringle/CastleRocktronics/releases/download/v0.5.0/CastleRocktronics-0.5.0-win.zip",
-      "sha256": "f16bc4328ca6ed5b84aecb4e2774b12ae755c953ef48d11d8ea76f30b1818438"
+      "sha256": "d70931b721ef4e150519b6440c1704f503621c302986c0ebf912c528875e9d3a"
     },
     "lin": {
       "download": "https://github.com/KieranPringle/CastleRocktronics/releases/download/v0.5.0/CastleRocktronics-0.5.0-lin.zip",


### PR DESCRIPTION
Contents of zip was changed after an issue was found. New sha256 is for the corrected zip (at the same url)