### PR TITLE
Fixed bad release.

### DIFF
--- a/plugins/mtsch-plugins.json
+++ b/plugins/mtsch-plugins.json
@@ -10,15 +10,15 @@
   "downloads": {
     "lin": {
       "download": "https://github.com/mtsch/mtsch-vcvrack-plugins/releases/download/v0.5.1/mtsch-plugins-0.5.1-lin.zip",
-      "sha256": "7e952548a19c33122b5644da698f626721f954db0f7d2ff9e69f48ec8efe46cc"
+      "sha256": "4a2e3d8ef0df76193ccf077b402ec77c3bafdea3e7d2ac60aa99834fa8e7f070"
     },
     "win": {
       "download": "https://github.com/mtsch/mtsch-vcvrack-plugins/files/1611272/mtsch-plugins-0.5.1-win.zip",
       "sha256": "60658d0959ca6902057e40003b5e216b6ae2de15f8bef0bfe21260adc018ccfd"
     },
     "mac": {
-        "download": "https://github.com/mtsch/mtsch-vcvrack-plugins/files/1611304/mtsch-plugins-0.5.1-mac.zip",
-        "sha256": "1723cf4e6e71bac8360ee0d00de2a3388130ce0fad8f877e90d453814bae2b9f"
+        "download": "https://github.com/mtsch/mtsch-vcvrack-plugins/releases/download/v0.5.1/mtsch-plugins-0.5.1-mac.zip",
+        "sha256": "51bb4e5b909cae23ceeb9695aefbcb4b42358056adabb47ca2336d34aeb734c8"
     }
   }
 }


### PR DESCRIPTION
Previous Linux and Mac releases contained no binaries because there was an error in the Makefile.