### PR TITLE
Update AS.json

### DIFF
--- a/plugins/AS.json
+++ b/plugins/AS.json
@@ -19,7 +19,7 @@
     },
     "mac": {
       "download": "https://github.com/AScustomWorks/AS/releases/download/0.5.3/AS-0.5.3-mac.zip",
-      "sha256": "7307e8eca28e56d4926eda216f1192d259345fbeeb7d8645c59c1450595d364d"
+      "sha256": "d0918685543fa4e0dd6756bc15073a207f5ae261034b540701b8b24fbfa4abd2"
     }
   }
 }


### PR DESCRIPTION
mac release 0.5.3 build had  previous version declared(0.5.2), going into the "red dot loop", fixed now and updated the sha256