### PR TITLE
Update CastleRocktronics.json

### DIFF
--- a/plugins/CastleRocktronics.json
+++ b/plugins/CastleRocktronics.json
@@ -10,7 +10,7 @@
   "downloads": {
     "win": {
       "download": "https://github.com/KieranPringle/CastleRocktronics/releases/download/v0.5.0/CastleRocktronics-0.5.0-win.zip",
-      "sha256": "d70931b721ef4e150519b6440c1704f503621c302986c0ebf912c528875e9d3a"
+      "sha256": "2d3fd769567b10d730f051f8dd9d2ce360a2cdae244f34c3d478c363520712bc"
     },
     "lin": {
       "download": "https://github.com/KieranPringle/CastleRocktronics/releases/download/v0.5.0/CastleRocktronics-0.5.0-lin.zip",


### PR DESCRIPTION
Windows binary had the wrong root directory name. The link to the fixed one is the same, but the sha256 is not

Relates to https://github.com/VCVRack/community/issues/200