### PR TITLE
Update Ohmer.json v0.5.4 incl. fixed Mac version

### DIFF
--- a/plugins/Ohmer.json
+++ b/plugins/Ohmer.json
@@ -11,11 +11,11 @@
   "downloads": {
     "win": {
       "download": "https://github.com/DomiKamu/Ohmer-Modules/releases/download/v0.5.4/Ohmer-0.5.4-win.zip",
-      "sha256": "b952bd78647fcbd543a313b5e664844f7b7e0264aabe0f7c33b5186ae8d144a7"
+      "sha256": "7da89cb6a157cb50d7153d4d8ec58603ff554d084b2a0b557d6861bd6e27607d"
     },
     "mac": {
-      "download": "https://github.com/DomiKamu/Ohmer-Modules/releases/download/v0.5.3/Ohmer-0.5.3-mac.zip",
-      "sha256": "e839d3e51b35d04bf797eca077c9f97c7817edf3bec30de37364c8908fab0a50"
+      "download": "https://github.com/DomiKamu/Ohmer-Modules/releases/download/v0.5.4/Ohmer-0.5.4-mac.zip",
+      "sha256": "1e02b24f03085a4c964cf9802e01c6a205d70171f63999d8e08b334e69def7f1"
     }
   }
 }


### PR DESCRIPTION
Previous version number for MacOS was bad (0.5.3, instead of 0.5.4).