### PR TITLE
Update Makefile to return proper exit codes of sub-make commands.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 # Convert relative Rack directory path to absolute
 RACK_DIR := $(shell realpath $(RACK_DIR))
 
+REPOS ?= $(shell ls repos)
 
-dist_all:
-	for f in repos/*; do $(MAKE) -C "$$f" dist; done
+dist_all: $(REPOS)
+
+$(REPOS):
+	$(MAKE) -C repos/$@ dist
+
+.PHONY: dist_all $(REPOS)


### PR DESCRIPTION
Right now, the shell `for` loop in the Makefile swallows the return code of the `make` command in each repository. It returns 0 always.

The proposed changes propagate the child-make return code up to the parent `Makefile` and allow to catch build failures instead of them being silently ignored.

`REPOS` can also be provided on the command line to limit the plugins to build (for testing).