### PR TITLE
Add WiggleRoom plugin v2.1.0

### DIFF
--- a/manifests/WiggleRoom.json
+++ b/manifests/WiggleRoom.json
@@ -1,0 +1,37 @@
+{
+  "slug": "WiggleRoom",
+  "name": "Wiggle Room",
+  "version": "2.1.0",
+  "license": "GPL-3.0-or-later",
+  "brand": "Wiggle Room",
+  "author": "Tim Richardson",
+  "authorEmail": "",
+  "authorUrl": "",
+  "pluginUrl": "https://github.com/timini/WiggleRoom",
+  "manualUrl": "https://github.com/timini/WiggleRoom#documentation",
+  "sourceUrl": "https://github.com/timini/WiggleRoom",
+  "donateUrl": "",
+  "changelogUrl": "https://github.com/timini/WiggleRoom/releases",
+  "modules": [
+    {
+      "slug": "Matter",
+      "name": "Matter",
+      "description": "Physical model of a struck solid inside a resonant tube - morphs from strings to bells with acoustic chamber",
+      "tags": [
+        "Physical modeling",
+        "Instrument",
+        "Oscillator"
+      ]
+    },
+    {
+      "slug": "ACID9Voice",
+      "name": "ACID9 Voice",
+      "description": "TB-303 inspired acid synthesizer voice with tri-core morphing oscillator, dual filters (ACID/LEAD), stereo delay with ghost mode, and accent/slide control",
+      "tags": [
+        "Synth voice",
+        "Oscillator",
+        "Filter"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## New Plugin: WiggleRoom

Physical modeling instruments and acid synthesis for VCV Rack 2, built with Faust DSP.

### Modules

| Module | Tags | Description |
|--------|------|-------------|
| **Matter** | Physical modeling, Instrument, Oscillator | Struck solid inside a resonant tube — morphs from strings to bells |
| **ACID9 Voice** | Synthesizer voice, Oscillator, Filter | TB-303 inspired acid synth with tri-core morphing oscillator and dual filters |

### Links

- **Source**: https://github.com/timini/WiggleRoom
- **Release**: https://github.com/timini/WiggleRoom/releases/tag/v2.1.0
- **License**: GPL-3.0-or-later
- **Author**: Tim Richardson